### PR TITLE
do not cause a dead lock when recursing into directories

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,6 @@ jspm_packages
 
 # Optional REPL history
 .node_repl_history
+
+# JetBrains IDEs
+.idea/

--- a/index.js
+++ b/index.js
@@ -28,7 +28,11 @@ function _retrieveFileIntegrities (rootDir, currDir, index) {
           const relativePath = path.relative(rootDir, fullPath)
           index[relativePath] = {
             size: stat.size,
-            generatingIntegrity: limit(() => ssri.fromStream(fs.createReadStream(fullPath)))
+            generatingIntegrity: limit(() => {
+              return stat.size < MAX_BULK_SIZE
+                     ? fs.readFile(fullPath).then(ssri.fromData)
+                     : ssri.fromStream(fs.createReadStream(fullPath))
+            })
           }
         }
       })

--- a/index.js
+++ b/index.js
@@ -11,52 +11,30 @@ const limit = pLimit(20)
 const MAX_BULK_SIZE = 1 * 1024 * 1024 // 1MB
 
 function generateFrom (dirname) {
-  return _generateFrom(path.resolve(dirname), '')
+  return _retrieveFileIntegrities(dirname, dirname, {})
 }
 
-function _generateFrom (file, fname) {
-  return fs.stat(file)
-    .then(stat => {
-      if (stat.isDirectory()) {
-        return fs.readdir(file)
-          .then(files => Promise.all(
-              files.map(f => limit(() => _generateFrom(path.join(file, f), path.join(fname, f))))
-            )
-          )
-          .then(files => {
-            return files.reduce((acc, info) => {
-              if (info) {
-                Object.assign(acc, info)
-              }
-              return acc
-            }, {})
-          })
-      }
-      if (!stat.isFile()) {
-        // ignored. We don't do things like symlinks rn
-        return
-      }
-      if (stat.size < MAX_BULK_SIZE) {
-        return {
-          [fname]: {
+function _retrieveFileIntegrities (rootDir, currDir, index) {
+  return fs.readdir(currDir)
+  .then((files) => {
+    return Promise.all(files.map((file) => {
+      const fullPath = path.join(currDir, file)
+      return fs.stat(fullPath)
+      .then((stat) => {
+        if (stat.isDirectory()) {
+          return _retrieveFileIntegrities(rootDir, fullPath, index)
+        }
+        if (stat.isFile()) {
+          const relativePath = path.relative(rootDir, fullPath)
+          index[relativePath] = {
             size: stat.size,
-            generatingIntegrity: fs.readFile(file)
-              .then(data => ssri.fromData(data))
+            generatingIntegrity: limit(() => ssri.fromStream(fs.createReadStream(fullPath)))
           }
         }
-      }
-      return {
-        [fname]: {
-          size: stat.size,
-          generatingIntegrity: ssri.fromStream(fs.createReadStream(file))
-        }
-      }
-    })
-    .catch({code: 'ENOENT'}, err => {
-      if (err.code !== 'ENOENT') {
-        throw err
-      }
-    })
+      })
+    }))
+  })
+  .then(() => index)
 }
 
 function check (dirname, dirIntegrity) {

--- a/shrinkwrap.yaml
+++ b/shrinkwrap.yaml
@@ -114,6 +114,7 @@ packages:
     resolution:
       integrity: sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=
   /any-promise/1.3.0:
+    dev: false
     resolution:
       integrity: sha1-q8av7tzqUugJzcA3au0845Y10X8=
   /argparse/1.0.9:


### PR DESCRIPTION
I've changed the code quite a bit, but the main change is that now `limit` is only applied on `ssri.fromStream`. I've also removed the call to `ssri.fromFile` for small files (while I was trying to figure out where the issue was) but I can put that back if you want.